### PR TITLE
GPT の API を叩く関数の追加

### DIFF
--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -81,7 +81,7 @@ def create_partition_prompt(taskname: str):
         "次のタスクを分解してください："
     )
 
-    return {"user_prompt": taskname, "system_prompt": system_prompt, "model": "GPT-3.5", "temparature": 0}
+    return {"user_prompt": taskname, "system_prompt": system_prompt, "model": "gpt-3.5-turbo", "temparature": 0}
 
 
 @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -1,0 +1,32 @@
+import os
+
+from openai import AsyncOpenAI
+from tenacity import RetryError, retry, stop_after_attempt, wait_fixed
+
+
+async def create_asyncClient() -> AsyncOpenAI:
+    client = await AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY_ENE"), timeout=15, max_retries=3)
+    return client
+
+
+def create_request(prompt):
+    return {
+        "model": "gpt-4o",
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant and have a plenty of knowledge about informatics.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        "temperature": 0,
+    }
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_fixed(2))
+async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
+    try:
+        res = await client.chat.completions.create(**create_request(prompt))
+        return res.choices[0].message.content
+    except RetryError:
+        return "ごめん、今忙しいからちょっと待ってね。"

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -9,7 +9,13 @@ async def create_asyncClient() -> AsyncOpenAI:
     return client
 
 
-def create_request(prompt):
+def create_request(username: str, taskname: str, duration: int, difficulty: int):
+    prompt = ""
+    prompt
+    username
+    taskname
+    duration
+    difficulty
     return {
         "model": "gpt-4o",
         "messages": [
@@ -17,7 +23,7 @@ def create_request(prompt):
                 "role": "system",
                 "content": "You are a helpful assistant and have a plenty of knowledge about informatics.",
             },
-            {"role": "user", "content": prompt},
+            {"role": "user", "content": ""},
         ],
         "temperature": 0,
     }

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -21,7 +21,7 @@ def create_compliment_prompt(username: str, taskname: str, duration: int, diffic
 
     li_username_prompt = ["KU-onji", "ふじ", "んど"]
     li_taskname_prompt = ["言語処理レポート", "牛乳買う", "バイト"]
-    li_duration_prompt = [300, 20, 85]
+    li_duration_prompt = [300, 20, 170]
     li_difficulty_prompt = [85, 15, 50]
     li_compliment_prompt = [
         "うん、いい感じじゃん。KU-onjiも頑張ってるし、私も頑張らなきゃな。ひとまず休憩だね。レポートお疲れ様。",

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -85,9 +85,9 @@ def create_partition_prompt(taskname: str):
 
 
 @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
-async def call_gpt_async(client: AsyncOpenAI, prompt) -> tuple[str, int]:
+async def call_gpt_async(client: AsyncOpenAI, prompt: dict) -> tuple[str, int]:
     try:
-        res = await client.chat.completions.create(**create_request(prompt))
+        res = await client.chat.completions.create(**create_request(**prompt))
         return res.choices[0].message.content
     except RetryError:
         return "ごめん、今忙しいからちょっと待ってね。"

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -10,7 +10,32 @@ async def create_asyncClient() -> AsyncOpenAI:
 
 
 def create_request(username: str, taskname: str, duration: int, difficulty: int):
-    prompt = ""
+    def create_oneShot(username: str, taskname: str, duration: int, difficulty: int, compliment: str = ""):
+        return (
+            f"ユーザー名: {username}\n"
+            f"タスク: {taskname}\n"
+            f"所要時間: {str(duration)}\n"
+            f"難易度: {str(difficulty)}\n"
+            f"褒め言葉: {compliment}\n\n"
+        )
+
+    prompt = (
+        "以下のフォーマットに従った入力が与えられます。フォーマットの内容に基づいて、親しい雰囲気でユーザーのことを褒めてください。"
+        "ユーザーのモチベーションが上がるような褒め言葉が望ましいです。\n\n"
+        "ユーザー名: {ユーザーの名前}\n"
+        "タスク: {ユーザーが完了したタスク}\n"
+        "所要時間: {タスクにかかった時間; 単位は分}\n"
+        "難易度: {0から100で表されるタスクの難易度}\n"
+        "褒め言葉: {あなたの褒め言葉}\n\n"
+        "制約は以下の通りです。\n"
+        "- タスクの難易度が高く、所要時間が長いほど労いの気持ちを強める\n"
+        "- ユーザー名を含めるかどうかは任意\n"
+        "- タスクの内容を踏まえた褒め言葉を生成する\n"
+        "- 所要時間と難易度を出力してはいけない\n"
+        '- 一人称は"私"\n'
+        "- クールなお姉さんの口調で生成する\n\n"
+        "以下は出力例です。\n\n"
+    )
     prompt
     username
     taskname

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -23,7 +23,7 @@ def create_request(prompt):
     }
 
 
-@retry(stop=stop_after_attempt(3), wait=wait_fixed(2))
+@retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
 async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
     try:
         res = await client.chat.completions.create(**create_request(prompt))

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -85,7 +85,7 @@ def create_partition_prompt(taskname: str):
 
 
 @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))
-async def call_gpt_async(client: AsyncOpenAI, prompt: str) -> tuple[str, int]:
+async def call_gpt_async(client: AsyncOpenAI, prompt) -> tuple[str, int]:
     try:
         res = await client.chat.completions.create(**create_request(prompt))
         return res.choices[0].message.content

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -61,14 +61,14 @@ def create_compliment_prompt(username: str, taskname: str, duration: int, diffic
     return {"system_prompt": system_prompt, "user_prompt": user_prompt, "model": "gpt-4o", "temperature": 1}
 
 
-def create_request(system_prompt: str, user_prompt: str, model: str) -> dict:
+def create_request(system_prompt: str, user_prompt: str, model: str, temperature: int) -> dict:
     return {
         "model": model,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ],
-        "temperature": 1,
+        "temperature": temperature,
     }
 
 
@@ -81,7 +81,7 @@ def create_partition_prompt(taskname: str):
         "次のタスクを分解してください："
     )
 
-    return {"user_prompt": taskname, "system_prompt": system_prompt, "model": "gpt-3.5-turbo", "temparature": 0}
+    return {"user_prompt": taskname, "system_prompt": system_prompt, "model": "gpt-3.5-turbo", "temperature": 0}
 
 
 @retry(stop=stop_after_attempt(2), wait=wait_fixed(1))

--- a/ene_backend/utils/gpt_utils.py
+++ b/ene_backend/utils/gpt_utils.py
@@ -19,6 +19,16 @@ def create_request(username: str, taskname: str, duration: int, difficulty: int)
             f"褒め言葉: {compliment}\n\n"
         )
 
+    """ li_username_prompt = ["KU-onji", "ふじ", "んど"]
+    li_taskname_prompt = ["言語処理レポート", "牛乳買う", "バイト"]
+    li_duration_prompt = [300, 20, 85]
+    li_difficulty_prompt = [85, 15, 50]
+    li_compliment_prompt = [
+        "うん、いい感じじゃん。KU-onjiも頑張ってるし、私も頑張らなきゃな。ひとまず休憩だね。レポートお疲れ様。",
+        "いいね。あったかい牛乳でも飲む？",
+        "バイトお疲れ様。いい感じにこなせてるし、この調子で頑張ってね。",
+    ] """
+
     prompt = (
         "以下のフォーマットに従った入力が与えられます。フォーマットの内容に基づいて、親しい雰囲気でユーザーのことを褒めてください。"
         "ユーザーのモチベーションが上がるような褒め言葉が望ましいです。\n\n"
@@ -48,7 +58,7 @@ def create_request(username: str, taskname: str, duration: int, difficulty: int)
                 "role": "system",
                 "content": "You are a helpful assistant and have a plenty of knowledge about informatics.",
             },
-            {"role": "user", "content": ""},
+            {"role": "user", "content": prompt},
         ],
         "temperature": 0,
     }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1905,6 +1905,21 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
+name = "tenacity"
+version = "8.3.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-8.3.0-py3-none-any.whl", hash = "sha256:3649f6443dbc0d9b01b9d8020a9c4ec7a1ff5f6f3c6c8a036ef371f573fe9185"},
+    {file = "tenacity-8.3.0.tar.gz", hash = "sha256:953d4e6ad24357bceffbc9707bc74349aca9d245f68eb65419cf0c249a1949a2"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "tomlkit"
 version = "0.12.5"
 description = "Style preserving TOML library"
@@ -2515,4 +2530,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "0ba7c018826bfede8bd28cb9e8e11994ac3f23116fe6bd99a53cc692cf8aa557"
+content-hash = "b201cc12f43bd3673605ba5d4f831a87f6937965f19a76f193b6012518ee7579"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ python = "^3.12"
 openai = "^1.30.5"
 reflex = "^0.5.2"
 pre-commit = "^3.7.1"
+tenacity = "^8.3.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# やったこと
- GPT から褒め言葉を貰うためのプロンプトを返す関数 `create_complement_prompt` を実装
- タスクを分割するためのプロンプトを返す関数 `create_partition` を実装
- GPT から非同期にレスポンスを貰う関数 `call_gpt_async` を実装

# 変更に伴うお願い
環境変数 "OPENAI_API_KEY_ENE" に OpenAI の API Key を設定しておいてください。

# これからやること
フロントからこれらを呼び出す。