### PR TITLE
GPTに丸投げする機能のサンプルの実装

### DIFF
--- a/ene_backend/components/icon_dialog.py
+++ b/ene_backend/components/icon_dialog.py
@@ -3,19 +3,19 @@ import reflex as rx
 from ene_backend import styles
 
 
-def icon_dialog(dialog: tuple[str, str]) -> rx.Component:
+def icon_dialog(user_message: str, system_response: str) -> rx.Component:
     """Create a dialog box with icons.
 
     Args:
-        dialog: A pair of user message and system response.
+        user_message: The message from the user.
+        system_response: The response from the system.
 
     Returns:
         The dialog box component.
     """
-    user_message, system_response = dialog
     return rx.vstack(
         rx.box(
-            rx.markdown(
+            rx.text(
                 user_message,
                 background_color=rx.color("mint", 4),
                 **styles.message_style,
@@ -26,7 +26,7 @@ def icon_dialog(dialog: tuple[str, str]) -> rx.Component:
             _hover={"transform": "scale(1.1)"},
         ),
         rx.box(
-            rx.markdown(
+            rx.text(
                 system_response,
                 background_color=rx.color("gray", 5),
                 **styles.message_style,

--- a/ene_backend/pages/home.py
+++ b/ene_backend/pages/home.py
@@ -10,6 +10,7 @@ from ene_backend.components import (
     suggestion,
     task_table,
 )
+from ene_backend.state.chat_state import ChatState
 from ene_backend.templates import template
 from ene_backend.templates.template import ThemeState
 
@@ -24,14 +25,16 @@ def content_field(
     *contents: rx.Component,
 ) -> rx.Component:
     return rx.box(
-        rx.vstack(
-            *contents,
-            spacing="2",
-            width="100%",
-            height="100%",
-            align=align,
-            justify=justify,
-            # _hover={"background": "green"},  # for debugging
+        rx.scroll_area(
+            rx.vstack(
+                *contents,
+                spacing="2",
+                width="100%",
+                height="100%",
+                align=align,
+                justify=justify,
+                # _hover={"background": "green"},  # for debugging
+            ),
         ),
         border_radius="0.5em",
         padding="1em",
@@ -53,12 +56,14 @@ def button_boxes() -> rx.Component:
             rx.icon("message_circle"),
             "ほめて！",
             color_scheme="mint",
+            on_click=ChatState.answer,
             **styles.button_box_style,
         ),
         rx.button(
             rx.icon("lightbulb"),
             "それAIでどうにかならない？",
             color_scheme="jade",
+            on_click=ChatState.answer,
             **styles.button_box_style,
         ),
         rx.button(
@@ -185,8 +190,10 @@ def right_box() -> rx.Component:
             "80%",
             "start",
             "start",
-            icon_dialog.icon_dialog(("Hello", "Hi")),
-            icon_dialog.icon_dialog(("How are you?", "I'm fine.")),
+            rx.foreach(
+                ChatState.chat_history,
+                lambda dialog: icon_dialog.icon_dialog(dialog[0], dialog[1]),
+            ),
         ),
         button_boxes(),
         direction="column",

--- a/ene_backend/pages/home.py
+++ b/ene_backend/pages/home.py
@@ -63,7 +63,6 @@ def button_boxes() -> rx.Component:
             rx.icon("lightbulb"),
             "それAIでどうにかならない？",
             color_scheme="jade",
-            on_click=ChatState.answer,
             **styles.button_box_style,
         ),
         rx.button(

--- a/ene_backend/state/chat_state.py
+++ b/ene_backend/state/chat_state.py
@@ -1,0 +1,13 @@
+import reflex as rx
+
+
+class ChatState(rx.State):
+    question: str = "Hello!"
+    response: str = "Hello, world!"
+    chat_history: list[tuple[str, str]] = [
+        ("Hello", "Hi"),
+        ("How are you?", "I'm fine."),
+    ]
+
+    def answer(self):
+        self.chat_history.append((self.question, self.response))


### PR DESCRIPTION
- チャットの履歴を保持する`ChatState`の実装
- `content_field()`でスクロールできるように変更
- 「ほめて！」ボタンかGPTに丸投げするボタンを押すと、チャットのサンプルを投げるように変更
