### PR TITLE
チャットの横幅の固定

### DIFF
--- a/ene_backend/components/icon_dialog.py
+++ b/ene_backend/components/icon_dialog.py
@@ -44,7 +44,7 @@ def icon_dialog(user_message: str, system_response: str) -> rx.Component:
                 # _hover={"transform": "scale(1.1)"},
             ),
         ),
-        width="inherit",
+        width="40em",
         padding_x="1em",
         justify="between",
         align="stretch",

--- a/ene_backend/pages/home.py
+++ b/ene_backend/pages/home.py
@@ -35,6 +35,7 @@ def content_field(
                 justify=justify,
                 # _hover={"background": "green"},  # for debugging
             ),
+            width="100%",
         ),
         border_radius="0.5em",
         padding="1em",


### PR DESCRIPTION
チャットのウィンドウの横幅がメッセージの長さによって変化するのが不自然だったので固定しました。
ノートPCの画面サイズだと自然ですが大きなディスプレイに映すと右に空白があって微妙ですがこれ以上のやり方が分かりませんでした（誰かできそうならお願いします）